### PR TITLE
Add clearer link color for right sidebar

### DIFF
--- a/night-owl-ish.css
+++ b/night-owl-ish.css
@@ -29,6 +29,10 @@ textarea {
   max-width: 850px;
 }
 
+.bp3-button.bp3-minimal {
+  color: #ffa7c4;
+}
+
 .bp3-elevation-3 {
   background-color: #697098 !important;
 }

--- a/night-owl-ish.css
+++ b/night-owl-ish.css
@@ -33,6 +33,10 @@ textarea {
   color: #ffa7c4;
 }
 
+.bp3-button.bp3-minimal:hover {
+  color: #ffa7c4;
+}
+
 .bp3-elevation-3 {
   background-color: #697098 !important;
 }


### PR DESCRIPTION
The page link color is pinkish, so color the refs/mentions number in the right sidebar the same color (shows the mentions of a page in the sidebar)