### PR TITLE
Fix textarea width

### DIFF
--- a/mappletons.css
+++ b/mappletons.css
@@ -21,7 +21,7 @@ textarea {
 .roam-block-container {
   max-width: 1000px;
 }
-.roam-block {
+.roam-block, .rm-block-text {
   max-width: 850px;
 }
 

--- a/night-owl-ish.css
+++ b/night-owl-ish.css
@@ -25,7 +25,7 @@ textarea {
 .roam-block-container {
   max-width: 1000px;
 }
-.roam-block {
+.roam-block, .rm-block-text {
   max-width: 850px;
 }
 


### PR DESCRIPTION
Currently, when you click on a bullet to edit it, the width is different, and text gets reshuffled. This matches the width, so this doesn't happen.