### PR TITLE
suggest CodeMirror's height at night-owl theme

### DIFF
--- a/night-owl-ish.css
+++ b/night-owl-ish.css
@@ -230,7 +230,7 @@ a {
 
 .CodeMirror{
     font-family: 'Dank Mono' !important;
-    height:300px;
+    height:auto;
     color:white;
     direction:ltr;
     background: #182026 !important;


### PR DESCRIPTION
Hi, I use the night-owl theme at Roam Research. Thank you for providing it.

I think the CodeMirror seems to take up too much space when I want to write a few lines of code.
Why don't you change CodeMirror's height from `300px` to `auto`?

I hope you will consider this.